### PR TITLE
feat: add pickup-only notice

### DIFF
--- a/storefront/app/root.tsx
+++ b/storefront/app/root.tsx
@@ -96,7 +96,7 @@ export default function App() {
   const loaderData = useLoaderData<RootLoaderData>();
   const { collections } = loaderData;
   const { locale } = useLoaderData<typeof loader>();
-  const { i18n } = useTranslation();
+  const { i18n, t } = useTranslation();
   const {
     activeOrderFetcher,
     activeOrder,
@@ -128,6 +128,9 @@ export default function App() {
           cartQuantity={activeOrder?.totalQuantity ?? 0}
         />
         <main className="">
+          <div className="bg-yellow-50 text-center text-sm py-2">
+            {t('common.pickupNotice')}
+          </div>
           <Outlet
             context={{
               activeOrderFetcher,

--- a/storefront/public/locales/en.json
+++ b/storefront/public/locales/en.json
@@ -30,7 +30,8 @@
     "home": "Home",
     "logoAlt": "Vendure logo",
     "search": "Search",
-    "goHome": "Go home"
+    "goHome": "Go home",
+    "pickupNotice": "Vancouver pickup only, no shipping, collect within 48 hrs"
   },
   "address": {
     "new": "New address",

--- a/storefront/public/locales/es.json
+++ b/storefront/public/locales/es.json
@@ -30,7 +30,8 @@
     "home": "Hogar",
     "logoAlt": "logotipo de empresa",
     "search": "Buscar",
-    "goHome": "Vete a casa"
+    "goHome": "Vete a casa",
+    "pickupNotice": "Solo recogida en Vancouver, sin envíos, recoja dentro de 48 h"
   },
   "address": {
     "new": "Nueva direccion",

--- a/storefront/public/locales/pt-BR.json
+++ b/storefront/public/locales/pt-BR.json
@@ -30,7 +30,8 @@
     "home": "Lar",
     "logoAlt": "Logotipo da venda",
     "search": "Procurar",
-    "goHome": "Ir para casa"
+    "goHome": "Ir para casa",
+    "pickupNotice": "Retirada somente em Vancouver, sem envio, retire em até 48 h"
   },
   "address": {
     "new": "Novo endereço",

--- a/storefront/public/locales/pt.json
+++ b/storefront/public/locales/pt.json
@@ -30,7 +30,8 @@
     "home": "Lar",
     "logoAlt": "Logotipo da venda",
     "search": "Procurar",
-    "goHome": "Ir para casa"
+    "goHome": "Ir para casa",
+    "pickupNotice": "Levantamento apenas em Vancouver, sem envios, levante dentro de 48 h"
   },
   "address": {
     "new": "Novo endereço",


### PR DESCRIPTION
## Summary
- note that orders are for Vancouver pickup only, no shipping, collect within 48 hrs
- localize pickup policy across supported languages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` (storefront)
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_68a4de18a654832a8b3cc6d812e2e9dd