### PR TITLE
feat: expire uncollected orders

### DIFF
--- a/src/order-expiration.plugin.ts
+++ b/src/order-expiration.plugin.ts
@@ -1,0 +1,79 @@
+import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import {
+    EventBus,
+    ID,
+    OrderProcess,
+    OrderService,
+    OrderStateTransitionEvent,
+    SchedulerService,
+    ScheduledTask,
+    VendurePlugin,
+    ConfigService,
+} from '@vendure/core';
+import { filter } from 'rxjs/operators';
+
+// Extend the OrderStates with a custom "Expired" state
+declare module '@vendure/core/dist/service/helpers/order-state-machine/order-state' {
+    interface CustomOrderStates {
+        Expired: never;
+    }
+}
+
+const orderExpirationProcess: OrderProcess<'Expired'> = {
+    transitions: {
+        PaymentSettled: { to: ['Expired', 'Completed'] },
+    },
+};
+
+@Injectable()
+export class OrderExpirationService implements OnApplicationBootstrap {
+    constructor(
+        private eventBus: EventBus,
+        private schedulerService: SchedulerService,
+        private configService: ConfigService,
+    ) {}
+
+    onApplicationBootstrap() {
+        this.eventBus
+            .ofType(OrderStateTransitionEvent)
+            .pipe(filter(event => event.toState === 'PaymentSettled'))
+            .subscribe(event => {
+                const taskId = `expire-order-${event.order.id}`;
+                const task = new ScheduledTask<{ orderId: ID }>({
+                    id: taskId,
+                    schedule: new Date(Date.now() + 48 * 60 * 60 * 1000) as any,
+                    params: { orderId: event.order.id },
+                    execute: async ({ injector, scheduledContext, params }) => {
+                        const orderService = injector.get(OrderService);
+                        const order = await orderService.findOne(scheduledContext, params.orderId);
+                        if (order && order.state !== 'Completed') {
+                            await orderService.transitionToState(scheduledContext, params.orderId, 'Expired');
+                            await orderService.addNoteToOrder(scheduledContext, {
+                                orderId: params.orderId,
+                                note: 'Order expired after 48h; no refund',
+                            });
+                            // TODO: optionally send a follow-up email/SMS
+                        }
+                    },
+                });
+                const scheduler: any = this.schedulerService as any;
+                const strategy: any = this.configService.schedulerOptions.schedulerStrategy as any;
+                strategy.registerTask(task);
+                const job = scheduler.createCronJob(task);
+                scheduler.jobs.set(task.id, { task, job });
+            });
+    }
+}
+
+@VendurePlugin({
+    providers: [OrderExpirationService],
+    configuration: config => {
+        config.orderOptions = {
+            ...config.orderOptions,
+            process: [...(config.orderOptions?.process ?? []), orderExpirationProcess],
+        };
+        return config;
+    },
+})
+export class OrderExpirationPlugin {}
+

--- a/src/vendure-config.ts
+++ b/src/vendure-config.ts
@@ -11,6 +11,7 @@ import { AdminUiPlugin } from '@vendure/admin-ui-plugin';
 import { GraphiqlPlugin } from '@vendure/graphiql-plugin';
 import 'dotenv/config';
 import path from 'path';
+import { OrderExpirationPlugin } from './order-expiration.plugin';
 
 const IS_DEV = process.env.APP_ENV === 'dev';
 const serverPort = +process.env.PORT || 3000;
@@ -90,5 +91,6 @@ export const config: VendureConfig = {
                 apiPort: serverPort,
             },
         }),
+        OrderExpirationPlugin,
     ],
 };


### PR DESCRIPTION
## Summary
- add OrderExpirationPlugin to automatically expire uncollected orders
- wire plugin into Vendure config and schedule checks using DefaultSchedulerPlugin

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: TS2307: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_68a4de0fb474832ab796e265d1e25364