### PR TITLE
feat: add pickup notification plugin

### DIFF
--- a/src/plugins/pickup-notification/index.ts
+++ b/src/plugins/pickup-notification/index.ts
@@ -1,0 +1,1 @@
+export * from './pickup-notification.plugin';

--- a/src/plugins/pickup-notification/pickup-notification.plugin.ts
+++ b/src/plugins/pickup-notification/pickup-notification.plugin.ts
@@ -1,0 +1,37 @@
+import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { PluginCommonModule, VendurePlugin, EventBus, OrderStateTransitionEvent } from '@vendure/core';
+import { EmailService } from '@vendure/email-plugin';
+
+/**
+ * Sends a pickup notification when an order is paid or fulfilled.
+ */
+@Injectable()
+class PickupNotificationService implements OnApplicationBootstrap {
+    constructor(private eventBus: EventBus, private emailService: EmailService) {}
+
+    onApplicationBootstrap() {
+        this.eventBus.ofType(OrderStateTransitionEvent).subscribe(async (event) => {
+            if (event.toState === 'PaymentSettled' || event.toState === 'Fulfilled') {
+                const order = event.order;
+                const emailAddress = order.customer?.emailAddress;
+                if (emailAddress) {
+                    const pickupAddress = process.env.PICKUP_ADDRESS ?? '123 Flower St.';
+                    const subject = `Order ${order.code} ready for pickup`;
+                    const body = `<p>Your order <strong>${order.code}</strong> is ready for pickup at ${pickupAddress}. Please collect within 48 hours.</p>`;
+                    await this.emailService.send({
+                        recipient: emailAddress,
+                        subject,
+                        body,
+                    });
+                }
+            }
+        });
+    }
+}
+
+@VendurePlugin({
+    imports: [PluginCommonModule],
+    providers: [PickupNotificationService],
+})
+export class PickupNotificationPlugin {}
+

--- a/src/vendure-config.ts
+++ b/src/vendure-config.ts
@@ -9,6 +9,7 @@ import { defaultEmailHandlers, EmailPlugin, FileBasedTemplateLoader } from '@ven
 import { AssetServerPlugin } from '@vendure/asset-server-plugin';
 import { AdminUiPlugin } from '@vendure/admin-ui-plugin';
 import { GraphiqlPlugin } from '@vendure/graphiql-plugin';
+import { PickupNotificationPlugin } from './plugins/pickup-notification';
 import 'dotenv/config';
 import path from 'path';
 
@@ -83,6 +84,7 @@ export const config: VendureConfig = {
                 changeEmailAddressUrl: 'http://localhost:8080/verify-email-address-change'
             },
         }),
+        PickupNotificationPlugin,
         AdminUiPlugin.init({
             route: 'admin',
             port: serverPort + 2,


### PR DESCRIPTION
## Summary
- add pickup notification plugin that emails customers when orders are settled or fulfilled
- wire plugin into Vendure config

## Testing
- `npm run build` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_68a4db9be0e4832a82ca1d337e8de8f8