### PR TITLE
Switch order confirmation to in-store pickup

### DIFF
--- a/static/email/templates/order-confirmation/body.hbs
+++ b/static/email/templates/order-confirmation/body.hbs
@@ -69,19 +69,13 @@
 <mj-section css-class="bg-off-white">
     <mj-column>
         <mj-text>
-            {{#with order.shippingAddress }}
-                <h3>Shipping To: {{ fullName }}</h3>
-                <ul class="address">
-                    {{#if company}}<li>{{ company }}</li>{{/if}}
-                    {{#if streetLine1}}<li>{{ streetLine1 }}</li>{{/if}}
-                    {{#if streetLine2}}<li>{{ streetLine2 }}</li>{{/if}}
-                    {{#if city}}<li>{{ city }}</li>{{/if}}
-                    {{#if province}}<li>{{ province }}</li>{{/if}}
-                    {{#if postalCode}}<li>{{ postalCode }}</li>{{/if}}
-                    {{#if country}}<li>{{ country }}</li>{{/if}}
-                    {{#if phoneNumber}}<li>{{ phoneNumber }}</li>{{/if}}
-                </ul>
-            {{/with}}
+            <h3>Pickup Location:</h3>
+            <ul class="address">
+                <li>123 Flower Street</li>
+                <li>Springfield, IL 62704</li>
+            </ul>
+            <p>Pickup Hours: 9am–5pm Mon–Sat</p>
+            <p>Please collect your order within 48 hours. No refunds after this period.</p>
         </mj-text>
     </mj-column>
 </mj-section>
@@ -116,12 +110,6 @@
                 <td colspan="3">Sub-total:</td>
                 <td>{{ formatMoney order.subTotalWithTax order.currencyCode 'en' }}</td>
             </tr>
-            {{#each shippingLines }}
-            <tr class="order-row">
-                <td colspan="3">Shipping ({{ shippingMethod.name }}):</td>
-                <td>{{ formatMoney priceWithTax ../order.currencyCode 'en' }}</td>
-            </tr>
-            {{/each}}
             <tr class="order-row total-row">
                 <td colspan="3">Total:</td>
                 <td>{{ formatMoney order.totalWithTax order.currencyCode 'en' }}</td>

--- a/storefront/public/locales/en.json
+++ b/storefront/public/locales/en.json
@@ -102,7 +102,7 @@
   "cart": {
     "title": "Shopping cart",
     "empty": "Your cart is empty",
-    "shippingMessage": "Shipping will be calculated at checkout.",
+    "shippingMessage": "Please collect your order within 48 hours. No refunds after this period.",
     "checkout": "Checkout"
   },
   "checkout": {
@@ -138,7 +138,7 @@
     "actions": "Actions",
     "actionsMessage": "Actions for this order (Not implemented)",
     "expand": "Expand this order",
-    "notShipped": "Not shipped yet",
+    "notShipped": "Awaiting pickup",
     "trackAlert": "Here you'd need to Link your delivery service. Tracking code for this package is",
     "trackPackage": "Track package",
     "detailedOverview": "Detailed overview",

--- a/storefront/public/locales/es.json
+++ b/storefront/public/locales/es.json
@@ -102,7 +102,7 @@
   "cart": {
     "title": "Carro de la compra",
     "empty": "Tu carrito esta vacío",
-    "shippingMessage": "El envío se calculará al finalizar la compra.",
+    "shippingMessage": "Recoge tu pedido en un plazo de 48 horas. No hay reembolsos después de ese período.",
     "checkout": "Verificar"
   },
   "checkout": {
@@ -138,7 +138,7 @@
     "actions": "Comportamiento",
     "actionsMessage": "Acciones para esta orden (No implementada)",
     "expand": "Ampliar este pedido",
-    "notShipped": "No enviado aún",
+    "notShipped": "Pendiente de recoger",
     "trackAlert": "Aquí deberá vincular su servicio de entrega. ",
     "trackPackage": "Paquete de seguimiento",
     "detailedOverview": "Descripción detallada",

--- a/storefront/public/locales/pt-BR.json
+++ b/storefront/public/locales/pt-BR.json
@@ -102,7 +102,7 @@
   "cart": {
     "title": "Carrinho de compras",
     "empty": "Seu carrinho está vazio",
-    "shippingMessage": "O frete será calculado na finalização da compra.",
+    "shippingMessage": "Retire seu pedido em até 48 horas. Não há reembolsos após esse período.",
     "checkout": "Confira"
   },
   "checkout": {
@@ -138,7 +138,7 @@
     "actions": "Ações",
     "actionsMessage": "Ações para este pedido (não implementadas)",
     "expand": "Expandir este pedido",
-    "notShipped": "Ainda não foi enviado",
+    "notShipped": "Aguardando retirada",
     "trackAlert": "Aqui você precisa vincular seu serviço de entrega. ",
     "trackPackage": "Rastrear pacote",
     "detailedOverview": "Visão geral detalhada",

--- a/storefront/public/locales/pt.json
+++ b/storefront/public/locales/pt.json
@@ -102,7 +102,7 @@
   "cart": {
     "title": "Carrinho de compras",
     "empty": "Seu carrinho está vazio",
-    "shippingMessage": "O frete será calculado na finalização da compra.",
+    "shippingMessage": "Levante a sua encomenda em 48 horas. Sem reembolsos após esse período.",
     "checkout": "Confira"
   },
   "checkout": {
@@ -138,7 +138,7 @@
     "actions": "Ações",
     "actionsMessage": "Ações para este pedido (não implementadas)",
     "expand": "Expandir este pedido",
-    "notShipped": "Ainda não foi enviado",
+    "notShipped": "Aguardando levantamento",
     "trackAlert": "Aqui você precisa vincular seu serviço de entrega. ",
     "trackPackage": "Rastrear pacote",
     "detailedOverview": "Visão geral detalhada",


### PR DESCRIPTION
## Summary
- remove shipping address and cost rows from order confirmation email
- add pickup location, hours and 48-hour no-refund policy
- update locale translations to reflect pickup policy

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: cannot find modules / TypeScript errors in storefront build)*

------
https://chatgpt.com/codex/tasks/task_e_68a4db97f968832a9bfa043d48838c35