### PR TITLE
Switch checkout to pickup

### DIFF
--- a/storefront/app/generated/graphql.ts
+++ b/storefront/app/generated/graphql.ts
@@ -4626,23 +4626,6 @@ export type OrderDetailFragment = {
     lastName: string;
     emailAddress: string;
   } | null;
-  shippingAddress?: {
-    __typename?: 'OrderAddress';
-    fullName?: string | null;
-    streetLine1?: string | null;
-    streetLine2?: string | null;
-    company?: string | null;
-    city?: string | null;
-    province?: string | null;
-    postalCode?: string | null;
-    countryCode?: string | null;
-    phoneNumber?: string | null;
-  } | null;
-  shippingLines: Array<{
-    __typename?: 'ShippingLine';
-    priceWithTax: number;
-    shippingMethod: { __typename?: 'ShippingMethod'; id: string; name: string };
-  }>;
   lines: Array<{
     __typename?: 'OrderLine';
     id: string;
@@ -5031,24 +5014,6 @@ export const OrderDetailFragmentDoc = gql`
       firstName
       lastName
       emailAddress
-    }
-    shippingAddress {
-      fullName
-      streetLine1
-      streetLine2
-      company
-      city
-      province
-      postalCode
-      countryCode
-      phoneNumber
-    }
-    shippingLines {
-      shippingMethod {
-        id
-        name
-      }
-      priceWithTax
     }
     lines {
       id

--- a/storefront/app/providers/orders/order.ts
+++ b/storefront/app/providers/orders/order.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 import { QueryOptions, sdk } from '../../graphqlWrapper';
-import { CreateAddressInput, CreateCustomerInput } from '~/generated/graphql';
+import { CreateCustomerInput } from '~/generated/graphql';
 
 export function getActiveOrder(options: QueryOptions) {
   return sdk
@@ -47,46 +47,9 @@ export function setCustomerForOrder(
   return sdk.setCustomerForOrder({ input }, options);
 }
 
-export function setOrderShippingAddress(
-  input: CreateAddressInput,
-  options: QueryOptions,
-) {
-  return sdk.setOrderShippingAddress({ input }, options);
-}
-
-export function setOrderShippingMethod(
-  shippingMethodId: string,
-  options: QueryOptions,
-) {
-  return sdk.setOrderShippingMethod({ shippingMethodId }, options);
-}
-
 gql`
   mutation setCustomerForOrder($input: CreateCustomerInput!) {
     setCustomerForOrder(input: $input) {
-      ...OrderDetail
-      ... on ErrorResult {
-        errorCode
-        message
-      }
-    }
-  }
-`;
-
-gql`
-  mutation setOrderShippingAddress($input: CreateAddressInput!) {
-    setOrderShippingAddress(input: $input) {
-      ...OrderDetail
-      ... on ErrorResult {
-        errorCode
-        message
-      }
-    }
-  }
-`;
-gql`
-  mutation setOrderShippingMethod($shippingMethodId: [ID!]!) {
-    setOrderShippingMethod(shippingMethodId: $shippingMethodId) {
       ...OrderDetail
       ... on ErrorResult {
         errorCode
@@ -168,24 +131,6 @@ gql`
       firstName
       lastName
       emailAddress
-    }
-    shippingAddress {
-      fullName
-      streetLine1
-      streetLine2
-      company
-      city
-      province
-      postalCode
-      countryCode
-      phoneNumber
-    }
-    shippingLines {
-      shippingMethod {
-        id
-        name
-      }
-      priceWithTax
     }
     lines {
       id

--- a/storefront/app/routes/api.active-order.tsx
+++ b/storefront/app/routes/api.active-order.tsx
@@ -4,19 +4,15 @@ import {
   getActiveOrder,
   removeOrderLine,
   setCustomerForOrder,
-  setOrderShippingAddress,
-  setOrderShippingMethod,
 } from '~/providers/orders/order';
 import { DataFunctionArgs, json } from '@remix-run/server-runtime';
 import {
-  CreateAddressInput,
   CreateCustomerInput,
   ErrorCode,
   ErrorResult,
   OrderDetailFragment,
 } from '~/generated/graphql';
 import { getSessionStorage } from '~/sessions';
-import { shippingFormDataIsValid } from '~/utils/validation';
 
 export type CartLoaderData = Awaited<ReturnType<typeof loader>>;
 
@@ -35,33 +31,6 @@ export async function action({ request, params }: DataFunctionArgs) {
     message: '',
   };
   switch (formAction) {
-    case 'setCheckoutShipping':
-      if (shippingFormDataIsValid(body)) {
-        const shippingFormData = Object.fromEntries<any>(
-          body.entries(),
-        ) as CreateAddressInput;
-        const result = await setOrderShippingAddress(
-          {
-            city: shippingFormData.city,
-            company: shippingFormData.company,
-            countryCode: shippingFormData.countryCode,
-            customFields: shippingFormData.customFields,
-            fullName: shippingFormData.fullName,
-            phoneNumber: shippingFormData.phoneNumber,
-            postalCode: shippingFormData.postalCode,
-            province: shippingFormData.province,
-            streetLine1: shippingFormData.streetLine1,
-            streetLine2: shippingFormData.streetLine2,
-          },
-          { request },
-        );
-        if (result.setOrderShippingAddress.__typename === 'Order') {
-          activeOrder = result.setOrderShippingAddress;
-        } else {
-          error = result.setOrderShippingAddress;
-        }
-      }
-      break;
     case 'setOrderCustomer': {
       const customerData = Object.fromEntries<any>(
         body.entries(),
@@ -78,20 +47,6 @@ export async function action({ request, params }: DataFunctionArgs) {
         activeOrder = result.setCustomerForOrder;
       } else {
         error = result.setCustomerForOrder;
-      }
-      break;
-    }
-    case 'setShippingMethod': {
-      const shippingMethodId = body.get('shippingMethodId');
-      if (typeof shippingMethodId === 'string') {
-        const result = await setOrderShippingMethod(shippingMethodId, {
-          request,
-        });
-        if (result.setOrderShippingMethod.__typename === 'Order') {
-          activeOrder = result.setOrderShippingMethod;
-        } else {
-          error = result.setOrderShippingMethod;
-        }
       }
       break;
     }

--- a/storefront/app/routes/checkout._index.tsx
+++ b/storefront/app/routes/checkout._index.tsx
@@ -8,17 +8,9 @@ import {
 } from '@remix-run/react';
 import { OutletContext } from '~/types';
 import { DataFunctionArgs, json, redirect } from '@remix-run/server-runtime';
-import {
-  getAvailableCountries,
-  getEligibleShippingMethods,
-} from '~/providers/checkout/checkout';
-import { shippingFormDataIsValid } from '~/utils/validation';
 import { getSessionStorage } from '~/sessions';
 import { classNames } from '~/utils/class-names';
-import { getActiveCustomerAddresses } from '~/providers/customer/customer';
-import { AddressForm } from '~/components/account/AddressForm';
-import { ShippingMethodSelector } from '~/components/checkout/ShippingMethodSelector';
-import { ShippingAddressSelector } from '~/components/checkout/ShippingAddressSelector';
+import { getActiveCustomerDetails } from '~/providers/customer/customer';
 import { getActiveOrder } from '~/providers/orders/order';
 import { useTranslation } from 'react-i18next';
 
@@ -29,7 +21,6 @@ export async function loader({ request }: DataFunctionArgs) {
 
   const activeOrder = await getActiveOrder({ request });
 
-  //check if there is an active order if not redirect to homepage
   if (
     !session ||
     !activeOrder ||
@@ -38,42 +29,25 @@ export async function loader({ request }: DataFunctionArgs) {
   ) {
     return redirect('/');
   }
-  const { availableCountries } = await getAvailableCountries({ request });
-  const { eligibleShippingMethods } = await getEligibleShippingMethods({
-    request,
-  });
-  const { activeCustomer } = await getActiveCustomerAddresses({ request });
+
+  const { activeCustomer } = await getActiveCustomerDetails({ request });
   const error = session.get('activeOrderError');
   return json({
-    availableCountries,
-    eligibleShippingMethods,
     activeCustomer,
     error,
   });
 }
 
-export default function CheckoutShipping() {
-  const { availableCountries, eligibleShippingMethods, activeCustomer, error } =
-    useLoaderData<typeof loader>();
+export default function CheckoutPickup() {
+  const { activeCustomer, error } = useLoaderData<typeof loader>();
   const { activeOrderFetcher, activeOrder } = useOutletContext<OutletContext>();
   const [customerFormChanged, setCustomerFormChanged] = useState(false);
-  const [addressFormChanged, setAddressFormChanged] = useState(false);
-  const [selectedAddressIndex, setSelectedAddressIndex] = useState(0);
   let navigate = useNavigate();
   const { t } = useTranslation();
 
-  const { customer, shippingAddress } = activeOrder ?? {};
+  const { customer } = activeOrder ?? {};
   const isSignedIn = !!activeCustomer?.id;
-  const addresses = activeCustomer?.addresses ?? [];
-  const defaultFullName =
-    shippingAddress?.fullName ??
-    (customer ? `${customer.firstName} ${customer.lastName}` : ``);
-  const canProceedToPayment =
-    customer &&
-    ((shippingAddress?.streetLine1 && shippingAddress?.postalCode) ||
-      selectedAddressIndex != null) &&
-    activeOrder?.shippingLines?.length &&
-    activeOrder?.lines?.length;
+  const canProceedToPayment = customer && activeOrder?.lines?.length;
 
   const submitCustomerForm = (event: FormEvent<HTMLFormElement>) => {
     const formData = new FormData(event.currentTarget);
@@ -95,67 +69,21 @@ export default function CheckoutShipping() {
       setCustomerFormChanged(false);
     }
   };
-  const submitAddressForm = (event: FormEvent<HTMLFormElement>) => {
-    const formData = new FormData(event.currentTarget);
-    const isValid = event.currentTarget.checkValidity();
-    if (addressFormChanged && isValid) {
-      setShippingAddress(formData);
-    }
-  };
-  const submitSelectedAddress = (index: number) => {
-    const selectedAddress = activeCustomer?.addresses?.[index];
-    if (selectedAddress) {
-      setSelectedAddressIndex(index);
-      const formData = new FormData();
-      Object.keys(selectedAddress).forEach((key) =>
-        formData.append(key, (selectedAddress as any)[key]),
-      );
-      formData.append('countryCode', selectedAddress.country.code);
-      formData.append('action', 'setCheckoutShipping');
-      setShippingAddress(formData);
-    }
-  };
 
-  function setShippingAddress(formData: FormData) {
-    if (shippingFormDataIsValid(formData)) {
-      activeOrderFetcher.submit(formData, {
-        method: 'post',
-        action: '/api/active-order',
-      });
-      setAddressFormChanged(false);
-    }
-  }
-
-  const submitSelectedShippingMethod = (value?: string) => {
-    if (value) {
-      activeOrderFetcher.submit(
-        {
-          action: 'setShippingMethod',
-          shippingMethodId: value,
-        },
-        {
-          method: 'post',
-          action: '/api/active-order',
-        },
-      );
-    }
+  const navigateToPayment = () => {
+    navigate('/checkout/payment');
   };
-
-  function navigateToPayment() {
-    navigate('./payment');
-  }
 
   return (
-    <div>
+    <div className="flex flex-col max-w-lg mx-auto">
       <div>
         <h2 className="text-lg font-medium text-gray-900">
           {t('checkout.detailsTitle')}
         </h2>
-
-        {isSignedIn ? (
-          <div>
-            <p className="mt-2 text-gray-600">
-              {customer?.firstName} {customer?.lastName}
+        {customer ? (
+          <div className="mt-4 text-sm text-gray-700">
+            <p>
+              {customer.firstName} {customer.lastName}
             </p>
             <p>{customer?.emailAddress}</p>
           </div>
@@ -234,44 +162,12 @@ export default function CheckoutShipping() {
         )}
       </div>
 
-      <Form
-        method="post"
-        action="/api/active-order"
-        onBlur={submitAddressForm}
-        onChange={() => setAddressFormChanged(true)}
-      >
-        <input type="hidden" name="action" value="setCheckoutShipping" />
-        <div className="mt-10 border-t border-gray-200 pt-10">
-          <h2 className="text-lg font-medium text-gray-900">
-            {t('checkout.shippingTitle')}
-          </h2>
-        </div>
-        {isSignedIn && activeCustomer.addresses?.length ? (
-          <div>
-            <ShippingAddressSelector
-              addresses={activeCustomer.addresses}
-              selectedAddressIndex={selectedAddressIndex}
-              onChange={submitSelectedAddress}
-            />
-          </div>
-        ) : (
-          <AddressForm
-            availableCountries={activeOrder ? availableCountries : undefined}
-            address={shippingAddress}
-            defaultFullName={defaultFullName}
-          ></AddressForm>
-        )}
-      </Form>
-
       <div className="mt-10 border-t border-gray-200 pt-10">
-        <ShippingMethodSelector
-          eligibleShippingMethods={eligibleShippingMethods}
-          currencyCode={activeOrder?.currencyCode}
-          shippingMethodId={
-            activeOrder?.shippingLines[0]?.shippingMethod.id ?? ''
-          }
-          onChange={submitSelectedShippingMethod}
-        />
+        <h2 className="text-lg font-medium text-gray-900">
+          {t('checkout.pickupTitle')}
+        </h2>
+        <p className="mt-4 not-italic">{t('checkout.storeAddress')}</p>
+        <p className="mt-2">{t('checkout.pickupInstructions')}</p>
       </div>
 
       <button

--- a/storefront/app/routes/checkout.tsx
+++ b/storefront/app/routes/checkout.tsx
@@ -6,7 +6,7 @@ import { classNames } from '~/utils/class-names';
 import { CartTotals } from '~/components/cart/CartTotals';
 import { useTranslation } from 'react-i18next';
 
-const steps = ['shipping', 'payment', 'confirmation'];
+const steps = ['pickup', 'payment', 'confirmation'];
 
 export default function Checkout() {
   const outletContext = useOutletContext<OutletContext>();
@@ -14,7 +14,7 @@ export default function Checkout() {
   const location = useLocation();
   const { t } = useTranslation();
 
-  let state = 'shipping';
+  let state = 'pickup';
   if (location.pathname === '/checkout/payment') {
     state = 'payment';
   } else if (location.pathname.startsWith('/checkout/confirmation')) {
@@ -71,7 +71,7 @@ export default function Checkout() {
               <CartContents
                 orderLines={activeOrder?.lines ?? []}
                 currencyCode={activeOrder?.currencyCode!}
-                editable={state === 'shipping'}
+                editable={state === 'pickup'}
                 removeItem={removeItem}
                 adjustOrderLine={adjustOrderLine}
               ></CartContents>

--- a/storefront/public/locales/en.json
+++ b/storefront/public/locales/en.json
@@ -123,10 +123,12 @@
     "braintreeError": "Braintree error:",
     "stripeError": "Stripe error:",
     "detailsTitle": "Contact information",
-    "shippingTitle": "Shipping information",
+    "pickupTitle": "Pickup information",
+    "pickupInstructions": "Collect your order at our store during business hours.",
+    "storeAddress": "123 Flower Street, Springfield",
     "goToPayment": "Proceed to payment",
     "steps": {
-      "shipping": "Shipping",
+      "pickup": "Pickup",
       "payment": "Payment",
       "confirmation": "Confirmation"
     }


### PR DESCRIPTION
## Summary
- switch checkout flow to pickup instead of shipping
- display store address and pickup instructions in checkout
- remove server-side shipping address handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module, missing tsconfig options)*
- `(cd storefront && npm test)` *(fails: Missing script "test")*
- `(cd storefront && npm run build)`

------
https://chatgpt.com/codex/tasks/task_e_68a4d8b7f0f0832abcd64a968fee19dc